### PR TITLE
[BUG] Broken autoload.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -18,7 +18,7 @@
     },
     "autoload":{
       "files": [
-            "vendor/securesubmit/heartland-php/Hps.php"
+            "Hps.php"
         ]
     }
 }


### PR DESCRIPTION
You don't need the vendor path as the autoloader is a local path.
