### PR TITLE
wrong case causes AdditionalTxnFields not to populate in response

### DIFF
--- a/src/Entities/Credit/HpsReportTransactionDetails.php
+++ b/src/Entities/Credit/HpsReportTransactionDetails.php
@@ -42,7 +42,7 @@ class HpsReportTransactionDetails extends HpsAuthorization
         }
 
         if (isset($reportResponse->Data->AdditionalTxnFields)) {
-            $additionalTxnFields = $reportResponse->Data->additionalTxnFields;
+            $additionalTxnFields = $reportResponse->Data->AdditionalTxnFields;
             $details->memo = (isset($additionalTxnFields->Description) ? (string)$additionalTxnFields->Description : null);
             $details->invoiceNumber = (isset($additionalTxnFields->InvoiceNbr) ? (string)$additionalTxnFields->InvoiceNbr : null);
             $details->customerId = (isset($additionalTxnFields->CustomerId) ? (string)$additionalTxnFields->CustomerId : null);


### PR DESCRIPTION
`HpsReportTransactionDetails::fromDict` had a case error, which caused transaction detail report requests NOT to populate additional fields `memo`, `invoiceNumber` and `customerId`