### PR TITLE
Fixed token recursion problem when token is a string

### DIFF
--- a/src/Services/Gateway/HpsSoapGatewayService.php
+++ b/src/Services/Gateway/HpsSoapGatewayService.php
@@ -300,8 +300,9 @@ class HpsSoapGatewayService extends HpsGatewayServiceAbstract implements HpsGate
     public function _hydrateTokenData($token, DOMDocument $xml, $cardPresent = false, $readerPresent = false)
     {
         if (!$token instanceof HpsTokenData) {
+            $tokenValue = $token;
             $token = new HpsTokenData();
-            $token->tokenValue = $token;
+            $token->tokenValue = $tokenValue;
         }
 
         $tokenData = $xml->createElement('hps:TokenData');


### PR DESCRIPTION
When doing a $chargeService->charge() call with a token that is a string and not an instance of HpsTokenData the existing code assigns the new HpsTokenData instance to itself as the tokenValue property, this creates a recursion error. It should be assigning the token string rather than the token object.